### PR TITLE
export generalobj 

### DIFF
--- a/build.go
+++ b/build.go
@@ -58,7 +58,7 @@ type Culprit struct {
 	FullName    string
 }
 
-type generalObj struct {
+type GeneralObj struct {
 	Parameters              []Parameter              `json:"parameters"`
 	Causes                  []map[string]interface{} `json:"causes"`
 	BuildsByBranchName      map[string]Builds        `json:"buildsByBranchName"`
@@ -103,7 +103,7 @@ type TestResult struct {
 }
 
 type BuildResponse struct {
-	Actions   []generalObj
+	Actions   []GeneralObj
 	Artifacts []struct {
 		DisplayPath  string `json:"displayPath"`
 		FileName     string `json:"fileName"`
@@ -193,7 +193,7 @@ func (b *Build) Info() *BuildResponse {
 	return b.Raw
 }
 
-func (b *Build) GetActions() []generalObj {
+func (b *Build) GetActions() []GeneralObj {
 	return b.Raw.Actions
 }
 

--- a/folder.go
+++ b/folder.go
@@ -27,7 +27,7 @@ type Folder struct {
 }
 
 type FolderResponse struct {
-	Actions     []generalObj
+	Actions     []GeneralObj
 	Description string     `json:"description"`
 	DisplayName string     `json:"displayName"`
 	Name        string     `json:"name"`

--- a/job.go
+++ b/job.go
@@ -55,7 +55,7 @@ type ParameterDefinition struct {
 
 type JobResponse struct {
 	Class              string `json:"_class"`
-	Actions            []generalObj
+	Actions            []GeneralObj
 	Buildable          bool `json:"buildable"`
 	Builds             []JobBuild
 	Color              string      `json:"color"`

--- a/queue.go
+++ b/queue.go
@@ -60,7 +60,7 @@ type taskResponse struct {
 
 type generalAction struct {
 	Causes     []map[string]interface{}
-	Parameters []parameter
+	Parameters []Parameter
 }
 
 func (q *Queue) Tasks() []*Task {
@@ -114,7 +114,7 @@ func (t *Task) GetWhy() string {
 	return t.Raw.Why
 }
 
-func (t *Task) GetParameters() []parameter {
+func (t *Task) GetParameters() []Parameter {
 	for _, a := range t.Raw.Actions {
 		if a.Parameters != nil {
 			return a.Parameters


### PR DESCRIPTION
Enable mocking of gojenkins.Build object by ensuring Build, BuildResponse, GeneralObj, and Parameter are all exportable.